### PR TITLE
Move version to a separate file for Heroku

### DIFF
--- a/lib/venice.rb
+++ b/lib/venice.rb
@@ -1,6 +1,4 @@
 module Venice
-  VERSION = "0.0.1"
-
   def self.shared_secret
     @@shared_secret
   end

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -39,7 +39,7 @@ module Venice
     def perform_post(params)
       response = Excon.post(@verification_url, :headers => headers, :body => params.to_json)
 
-      Rails.logger.warn "PERFORM POST: #{response.body.inspect}"
+      Rails.logger.info "PERFORM POST: #{response.body.inspect}"
 
       JSON.parse(response.body)
     end

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -38,9 +38,6 @@ module Venice
 
     def perform_post(params)
       response = Excon.post(@verification_url, :headers => headers, :body => params.to_json)
-
-      Rails.logger.info "PERFORM POST: #{response.body.inspect}"
-
       JSON.parse(response.body)
     end
 

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -39,7 +39,7 @@ module Venice
     def perform_post(params)
       response = Excon.post(@verification_url, :headers => headers, :body => params.to_json)
 
-      Rails.logger.info "PERFORM POST: #{response.body.inspect}"
+      Rails.logger.warn "PERFORM POST: #{response.body.inspect}"
 
       JSON.parse(response.body)
     end

--- a/lib/venice/client.rb
+++ b/lib/venice/client.rb
@@ -38,6 +38,9 @@ module Venice
 
     def perform_post(params)
       response = Excon.post(@verification_url, :headers => headers, :body => params.to_json)
+
+      Rails.logger.info "PERFORM POST: #{response.body.inspect}"
+
       JSON.parse(response.body)
     end
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -109,7 +109,8 @@ module Venice
         :app_item_id => @app_item_id,
         :version_external_identifier => @version_external_identifier,
         :bid => @bid,
-        :bvrs => @bvrs
+        :bvrs => @bvrs,
+        :expires_at => @expires_at
       }
     end
 

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -75,6 +75,9 @@ module Venice
     # For auto-renewable subscriptions, returns the date the subscription will expire
     attr_reader :expires_at
 
+    # For an active subscription was renewed with transaction that took place after the receipt your server sent to the App Store, this is the latest receipt base64.
+    attr_accessor :latest_receipt
+
     def initialize(attributes = {})
       @quantity = Integer(attributes['quantity']) if attributes['quantity']
       @product_id = attributes['product_id']
@@ -136,6 +139,10 @@ module Venice
 
             if latest_receipt_attributes = json['latest_receipt_info']
               receipt.latest = Receipt.new(latest_receipt_attributes)
+            end
+
+            if latest_receipt_base64 = json['latest_receipt']
+              receipt.latest_receipt = latest_receipt_base64
             end
 
             if latest_expired_receipt_attributes = json['latest_expired_receipt_info']

--- a/lib/venice/version.rb
+++ b/lib/venice/version.rb
@@ -1,0 +1,3 @@
+module Venice
+  VERSION = "0.0.1"
+end

--- a/lib/venice/version.rb
+++ b/lib/venice/version.rb
@@ -1,3 +1,3 @@
 module Venice
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/lib/venice/version.rb
+++ b/lib/venice/version.rb
@@ -1,3 +1,3 @@
 module Venice
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/venice.gemspec
+++ b/venice.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "venice"
+
+require 'venice/version'
 
 Gem::Specification.new do |s|
   s.name        = "venice"


### PR DESCRIPTION
Heroku will not allow me to bundle install venice without it screaming: 

> Does it try to require a relative path? That's been removed in Ruby 1.9.

This is because the gemspec is requiring the whole gem just to get the version, which is requiring all sorts of other gems.  I've just moved the version to a different, separate file, and Heroku loves it again.

By the way, thanks a million for doing the recurring subscription work, it's awesome!
